### PR TITLE
Change wording for routeNotificationForFCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ class ExampleNotification extends Notification
 - `FCMMessageTopic`: Send notifications to topic(s).
 - `FCMMessageGroup`: Send notifications to group(s).
 
-In order for your notice to know who to send messages, you must add `routeNotificationForFCM` method to your notification model.
+In order for your notice to know who to send messages, you must add `routeNotificationForFCM` method to your notifiable model.
 
 ### Available message methods
 


### PR DESCRIPTION
Very minor, but more understandable wording for instructions relating to adding routeNotificationForFCM method to your notifiable model. The model is always referred to as "notifiable" in the context of notifications.